### PR TITLE
prevent nPredictedLevel out of array bound

### DIFF
--- a/include/MapPoint.h
+++ b/include/MapPoint.h
@@ -78,7 +78,7 @@ public:
 
     float GetMinDistanceInvariance();
     float GetMaxDistanceInvariance();
-    int PredictScale(const float &currentDist, const float &logScaleFactor);
+    int PredictScale(const float &currentDist, const float &logScaleFactor, const int mnScaleLevel);
 
 public:
     long unsigned int mnId;

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -318,7 +318,7 @@ bool Frame::isInFrustum(MapPoint *pMP, float viewingCosLimit)
         return false;
 
     // Predict scale in the image
-    const int nPredictedLevel = pMP->PredictScale(dist,mfLogScaleFactor);
+    const int nPredictedLevel = pMP->PredictScale(dist,mfLogScaleFactor, this->mnScaleLevels);
 
     // Data used by the tracking
     pMP->mbTrackInView = true;

--- a/src/MapPoint.cc
+++ b/src/MapPoint.cc
@@ -382,7 +382,7 @@ float MapPoint::GetMaxDistanceInvariance()
     return 1.2f*mfMaxDistance;
 }
 
-int MapPoint::PredictScale(const float &currentDist, const float &logScaleFactor)
+int MapPoint::PredictScale(const float &currentDist, const float &logScaleFactor, const int mnScaleLevel)
 {
     float ratio;
     {
@@ -390,7 +390,8 @@ int MapPoint::PredictScale(const float &currentDist, const float &logScaleFactor
         ratio = mfMaxDistance/currentDist;
     }
 
-    return ceil(log(ratio)/logScaleFactor);
+    int nScale = ceil(log(ratio)/logScaleFactor);
+    return max(0, min(nScale, mnScaleLevel-1));
 }
 
 } //namespace ORB_SLAM

--- a/src/ORBmatcher.cc
+++ b/src/ORBmatcher.cc
@@ -354,7 +354,7 @@ int ORBmatcher::SearchByProjection(KeyFrame* pKF, cv::Mat Scw, const vector<MapP
         if(PO.dot(Pn)<0.5*dist)
             continue;
 
-        int nPredictedLevel = pMP->PredictScale(dist,pKF->mfLogScaleFactor);
+        int nPredictedLevel = pMP->PredictScale(dist,pKF->mfLogScaleFactor, pKF->mnScaleLevels);
 
         // Search in a radius
         const float radius = th*pKF->mvScaleFactors[nPredictedLevel];
@@ -884,7 +884,7 @@ int ORBmatcher::Fuse(KeyFrame *pKF, const vector<MapPoint *> &vpMapPoints, const
         if(PO.dot(Pn)<0.5*dist3D)
             continue;
 
-        int nPredictedLevel = pMP->PredictScale(dist3D,pKF->mfLogScaleFactor);
+        int nPredictedLevel = pMP->PredictScale(dist3D,pKF->mfLogScaleFactor, pKF->mnScaleLevels);
 
         // Search in a radius
         const float radius = th*pKF->mvScaleFactors[nPredictedLevel];
@@ -1043,7 +1043,7 @@ int ORBmatcher::Fuse(KeyFrame *pKF, cv::Mat Scw, const vector<MapPoint *> &vpPoi
             continue;
 
         // Compute predicted scale level
-        const int nPredictedLevel = pMP->PredictScale(dist3D,pKF->mfLogScaleFactor);
+        const int nPredictedLevel = pMP->PredictScale(dist3D,pKF->mfLogScaleFactor, pKF->mnScaleLevels);
 
         // Search in a radius
         const float radius = th*pKF->mvScaleFactors[nPredictedLevel];
@@ -1183,7 +1183,7 @@ int ORBmatcher::SearchBySim3(KeyFrame *pKF1, KeyFrame *pKF2, vector<MapPoint*> &
             continue;
 
         // Compute predicted octave
-        const int nPredictedLevel = pMP->PredictScale(dist3D,pKF2->mfLogScaleFactor);
+        const int nPredictedLevel = pMP->PredictScale(dist3D,pKF2->mfLogScaleFactor, pKF2->mnScaleLevels);
 
         // Search in a radius
         const float radius = th*pKF2->mvScaleFactors[nPredictedLevel];
@@ -1263,7 +1263,7 @@ int ORBmatcher::SearchBySim3(KeyFrame *pKF1, KeyFrame *pKF2, vector<MapPoint*> &
             continue;
 
         // Compute predicted octave
-        const int nPredictedLevel = pMP->PredictScale(dist3D,pKF1->mfLogScaleFactor);
+        const int nPredictedLevel = pMP->PredictScale(dist3D,pKF1->mfLogScaleFactor, pKF1->mnScaleLevels);
 
         // Search in a radius of 2.5*sigma(ScaleLevel)
         const float radius = th*pKF1->mvScaleFactors[nPredictedLevel];
@@ -1520,7 +1520,7 @@ int ORBmatcher::SearchByProjection(Frame &CurrentFrame, KeyFrame *pKF, const set
                 if(dist3D<minDistance || dist3D>maxDistance)
                     continue;
 
-                int nPredictedLevel = pMP->PredictScale(dist3D,CurrentFrame.mfLogScaleFactor);
+                int nPredictedLevel = pMP->PredictScale(dist3D,CurrentFrame.mfLogScaleFactor, CurrentFrame.mnScaleLevels);
 
                 // Search in a window
                 const float radius = th*CurrentFrame.mvScaleFactors[nPredictedLevel];


### PR DESCRIPTION
The return value of `MapPoint::PredictScale` in the original ORB_SLAM2 has range of [0, pKF->mnScaleLevels-1] to prevent array access out of bound.
Added range checking code to this version.